### PR TITLE
Patch the BOM bug of the Emploi Store Dev directly in the library:

### DIFF
--- a/tests/emploi_store_test.py
+++ b/tests/emploi_store_test.py
@@ -150,6 +150,28 @@ class ResourceTest(unittest.TestCase):
 456,Ségond
 """, csv_content)
 
+    def test_to_csv_utf8_with_bom(self, mock_requests):
+        """Test the to_csv method when resource has the BOM bug."""
+        _setup_mock_requests(mock_requests, {
+            'success': True,
+            'result': {
+                'records': [
+                    {u'\ufeffCÖDE': '123', 'NAME': u'Fïrst'},
+                    {u'\ufeffCÖDE': '456', 'NAME': u'Ségond'},
+                ],
+            },
+        })
+        filename = self.tmpdir + '/bmo_2016.csv'
+
+        self.res.to_csv(filename)
+
+        with codecs.open(filename, 'r', 'utf-8') as csv_file:
+            csv_content = csv_file.read().replace('\r\n', '\n')
+        self.assertEqual(u"""CÖDE,NAME
+123,Fïrst
+456,Ségond
+""", csv_content)
+
 
 def _setup_mock_requests(
         mock_requests, get_json, post_json=None):


### PR DESCRIPTION
The Emploi Store Dev server serves data from CSV, some of them have a
BOM (https://en.wikipedia.org/wiki/Byte_order_mark) which modifies the
name of the first field in the header: "CODE" -> "\ufeffCODE".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bayesimpact/python-emploi-store/5) &emsp; Multiple assignees:&emsp;<img alt="@dedan" height="20" width="20" align="absmiddle" src="https://avatars.githubusercontent.com/u/196905?s=40&v=3">&nbsp;<a href="/bayesimpact/python-emploi-store/pulls/assigned/dedan">dedan</a>,&emsp;<img alt="@florianjourda" height="20" width="20" align="absmiddle" src="https://avatars.githubusercontent.com/u/4361853?s=40&v=3">&nbsp;<a href="/bayesimpact/python-emploi-store/pulls/assigned/florianjourda">florianjourda</a>
<!-- Reviewable:end -->
