### PR TITLE
Handle to_csv properly when resource contains int in Python 2.7.

### DIFF
--- a/emploi_store/__init__.py
+++ b/emploi_store/__init__.py
@@ -268,7 +268,7 @@ class Resource(object):
                 record = {_strip_bom(k): v for k, v in record.items()}
                 if need_utf8_encode:
                     record = {
-                        k.encode('utf-8'): v.encode('utf-8')
+                        k.encode('utf-8'): unicode(v).encode('utf-8')
                         for k, v in record.items()}
                 csv_writer.writerow(record)
 

--- a/tests/emploi_store_test.py
+++ b/tests/emploi_store_test.py
@@ -166,6 +166,28 @@ class ResourceTest(unittest.TestCase):
 456,Second
 """, csv_content)
 
+    def test_to_csv_number(self, mock_requests):
+        """Test the to_csv method when resource returns numbers directly."""
+        _setup_mock_requests(mock_requests, {
+            'success': True,
+            'result': {
+                'records': [
+                    {'CODE': 123, 'NAME': 'First'},
+                    {'CODE': 456, 'NAME': 'Second'},
+                ],
+            },
+        })
+        filename = self.tmpdir + '/bmo_2016.csv'
+
+        self.res.to_csv(filename)
+
+        with open(filename) as csv_file:
+            csv_content = csv_file.read().replace('\r\n', '\n')
+        self.assertEqual("""CODE,NAME
+123,First
+456,Second
+""", csv_content)
+
     def test_to_csv_utf8(self, mock_requests):
         """Test the to_csv method when resource has Unicode chars."""
         _setup_mock_requests(mock_requests, {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bayesimpact/python-emploi-store/13)
<!-- Reviewable:end -->
