### PR TITLE
Raise full HTTPError if something goes wrong in HTTP instead of wrapping it with an EnvironmentError that hides some info.

### DIFF
--- a/emploi_store/__init__.py
+++ b/emploi_store/__init__.py
@@ -102,9 +102,7 @@ class Client(object):
         req = requests.get(
             self.api_url + '/infotravail/v1' + action, params=params,
             headers={'Authorization': 'Bearer %s' % self.access_token(scope)})
-        if req.status_code != 200:
-            raise EnvironmentError(
-                'HTTP error %d for: \n%s' % (req.status_code, req.url))
+        req.raise_for_status()
         response = req.json()
         if not response.get('success'):
             return None
@@ -186,9 +184,7 @@ class Client(object):
         req = requests.get(
             self.api_url + '/labonneboite/v1/company/', params=params,
             headers={'Authorization': 'Bearer %s' % self.access_token(scope)})
-        if req.status_code != 200:
-            raise EnvironmentError(
-                'HTTP error %d for: \n%s' % (req.status_code, req.url))
+        req.raise_for_status()
         response = req.json()
         companies = response.get('companies')
         if companies:
@@ -216,9 +212,7 @@ class Client(object):
             self.api_url + '/retouralemploisuiteformation/v1/rank',
             params={'formacode': formacode, 'codeinseeville': city_id},
             headers={'Authorization': 'Bearer %s' % self.access_token(scope)})
-        if req.status_code != 200:
-            raise EnvironmentError(
-                'HTTP error %d for: \n%s' % (req.status_code, req.url))
+        req.raise_for_status()
         response = req.json()
         return response[0]
 
@@ -242,9 +236,7 @@ class Client(object):
             self.api_url + '/matchviasoftskills/v1/professions/job_skills',
             params={'code': rome},
             headers={'Authorization': 'Bearer %s' % self.access_token(scope)})
-        if req.status_code != 201:
-            raise EnvironmentError(
-                'HTTP error %d for: \n%s' % (req.status_code, req.url))
+        req.raise_for_status()
         response = req.json()
         skills = response.get('skills')
         if skills:


### PR DESCRIPTION
Use requests-mock package for testing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bayesimpact/python-emploi-store/32)
<!-- Reviewable:end -->
