### PR TITLE
Fix call to OAuth2 /access_token endpoint to send the realm parameter in the URL.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## v0.9.0 [2020-03-02]
+
+* Fix call to OAuth2 /access_token endpoint to send the realm parameter in the URL.
+
 ## v0.8.1 [2018-08-16]
 
 Not a real release, only updated testing and documentation.

--- a/emploi_store/__init__.py
+++ b/emploi_store/__init__.py
@@ -77,9 +77,8 @@ class Client(object):
                 return token.value
 
         auth_request = requests.post(
-            'https://entreprise.pole-emploi.fr/connexion/oauth2/access_token',
+            'https://entreprise.pole-emploi.fr/connexion/oauth2/access_token?realm=%2Fpartenaire',
             data={
-                'realm': '/partenaire',
                 'grant_type': 'client_credentials',
                 'client_id': self._client_id,
                 'client_secret': self._client_secret,

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 
 import setuptools
 
-__version__ = '0.8.2'
+__version__ = '0.9.0'
 
 setuptools.setup(
     name='python-emploi-store',

--- a/tests/emploi_store_test.py
+++ b/tests/emploi_store_test.py
@@ -34,7 +34,7 @@ class ClientTestCase(unittest.TestCase):
                 'scope=application_my-ID+my-scope' in data
 
         mock_requests.post(
-            'https://entreprise.pole-emploi.fr/connexion/oauth2/access_token',
+            'https://entreprise.pole-emploi.fr/connexion/oauth2/access_token?realm=%2Fpartenaire',
             additional_matcher=_match_request_data,
             json={'access_token': 'foobar'})
 
@@ -45,7 +45,7 @@ class ClientTestCase(unittest.TestCase):
         """Test the access_token method."""
 
         mock_requests.post(
-            'https://entreprise.pole-emploi.fr/connexion/oauth2/access_token',
+            'https://entreprise.pole-emploi.fr/connexion/oauth2/access_token?realm=%2Fpartenaire',
             status_code=401)
 
         with self.assertRaises(ValueError):
@@ -56,7 +56,7 @@ class ClientTestCase(unittest.TestCase):
         """Test the access_token just after a token was fetched."""
 
         mock_requests.post(
-            'https://entreprise.pole-emploi.fr/connexion/oauth2/access_token',
+            'https://entreprise.pole-emploi.fr/connexion/oauth2/access_token?realm=%2Fpartenaire',
             json={'access_token': 'first-token', 'expires_in': 500})
         now = datetime.datetime(2016, 3, 11)
         mock_datetime.datetime.now.return_value = now
@@ -65,7 +65,7 @@ class ClientTestCase(unittest.TestCase):
         self.client.access_token('my-scope')
 
         mock_requests.post(
-            'https://entreprise.pole-emploi.fr/connexion/oauth2/access_token',
+            'https://entreprise.pole-emploi.fr/connexion/oauth2/access_token?realm=%2Fpartenaire',
             json={'access_token': 'second-token', 'expires_in': 500})
         now += datetime.timedelta(seconds=40)
         mock_datetime.datetime.now.return_value = now
@@ -79,7 +79,7 @@ class ClientTestCase(unittest.TestCase):
         """Test the access_token just after a token was fetched."""
 
         mock_requests.post(
-            'https://entreprise.pole-emploi.fr/connexion/oauth2/access_token',
+            'https://entreprise.pole-emploi.fr/connexion/oauth2/access_token?realm=%2Fpartenaire',
             json={'access_token': 'first-token', 'expires_in': 20})
         now = datetime.datetime(2016, 3, 11)
         mock_datetime.datetime.now.return_value = now
@@ -90,7 +90,7 @@ class ClientTestCase(unittest.TestCase):
         now += datetime.timedelta(seconds=40)
         mock_datetime.datetime.now.return_value = now
         mock_requests.post(
-            'https://entreprise.pole-emploi.fr/connexion/oauth2/access_token',
+            'https://entreprise.pole-emploi.fr/connexion/oauth2/access_token?realm=%2Fpartenaire',
             json={'access_token': 'second token', 'expires_in': 20})
 
         token = self.client.access_token('my-scope')
@@ -101,7 +101,7 @@ class ClientTestCase(unittest.TestCase):
         """Test the get_lbb_companies method."""
 
         mock_requests.post(
-            'https://entreprise.pole-emploi.fr/connexion/oauth2/access_token',
+            'https://entreprise.pole-emploi.fr/connexion/oauth2/access_token?realm=%2Fpartenaire',
             json={'access_token': 'foobar'})
         mock_requests.get(
             'https://api.emploi-store.fr/partenaire/labonneboite/v1/company/?'
@@ -118,7 +118,7 @@ class ClientTestCase(unittest.TestCase):
         """Test the get_lbb_companies method using a city ID as input."""
 
         mock_requests.post(
-            'https://entreprise.pole-emploi.fr/connexion/oauth2/access_token',
+            'https://entreprise.pole-emploi.fr/connexion/oauth2/access_token?realm=%2Fpartenaire',
             json={'access_token': 'foobar'})
         mock_requests.get(
             'https://api.emploi-store.fr/partenaire/labonneboite/v1/company/?'
@@ -140,7 +140,7 @@ class ClientTestCase(unittest.TestCase):
         """Test the get_lbb_companies method if the server fails."""
 
         mock_requests.post(
-            'https://entreprise.pole-emploi.fr/connexion/oauth2/access_token',
+            'https://entreprise.pole-emploi.fr/connexion/oauth2/access_token?realm=%2Fpartenaire',
             json={'access_token': 'foobar'})
         mock_requests.get(
             'https://api.emploi-store.fr/partenaire/labonneboite/v1/company/?'
@@ -156,7 +156,7 @@ class ClientTestCase(unittest.TestCase):
         """Test the get_employment_rate_rank_for_training method."""
 
         mock_requests.post(
-            'https://entreprise.pole-emploi.fr/connexion/oauth2/access_token',
+            'https://entreprise.pole-emploi.fr/connexion/oauth2/access_token?realm=%2Fpartenaire',
             json={'access_token': 'foobar'})
         mock_requests.get(
             'https://api.emploi-store.fr/partenaire/retouralemploisuiteformation/v1/rank?'
@@ -189,7 +189,7 @@ class ClientTestCase(unittest.TestCase):
         """Test the get_employment_rate_rank_for_training method when the server fails."""
 
         mock_requests.post(
-            'https://entreprise.pole-emploi.fr/connexion/oauth2/access_token',
+            'https://entreprise.pole-emploi.fr/connexion/oauth2/access_token?realm=%2Fpartenaire',
             json={'access_token': 'foobar'})
         mock_requests.get(
             'https://api.emploi-store.fr/partenaire/retouralemploisuiteformation/v1/rank?'
@@ -205,7 +205,7 @@ class ClientTestCase(unittest.TestCase):
         """Test the match_via_soft_skills method."""
 
         mock_requests.post(
-            'https://entreprise.pole-emploi.fr/connexion/oauth2/access_token',
+            'https://entreprise.pole-emploi.fr/connexion/oauth2/access_token?realm=%2Fpartenaire',
             json={'access_token': 'foobar'})
         mock_requests.post(
             'https://api.emploi-store.fr/partenaire/matchviasoftskills/v1/professions/job_skills?'
@@ -230,7 +230,7 @@ class ClientTestCase(unittest.TestCase):
         """Test the match_via_soft_skills method when the server fails."""
 
         mock_requests.post(
-            'https://entreprise.pole-emploi.fr/connexion/oauth2/access_token',
+            'https://entreprise.pole-emploi.fr/connexion/oauth2/access_token?realm=%2Fpartenaire',
             json={'access_token': 'foobar'})
         mock_requests.post(
             'https://api.emploi-store.fr/partenaire/matchviasoftskills/v1/professions/job_skills?'
@@ -245,7 +245,7 @@ class ClientTestCase(unittest.TestCase):
         """Test the get_lbb_companies method to access data from La Bonne Alternance."""
 
         mock_requests.post(
-            'https://entreprise.pole-emploi.fr/connexion/oauth2/access_token',
+            'https://entreprise.pole-emploi.fr/connexion/oauth2/access_token?realm=%2Fpartenaire',
             json={'access_token': 'foobar'})
         mock_requests.get(
             'https://api.emploi-store.fr/partenaire/labonneboite/v1/company/?'
@@ -267,7 +267,7 @@ class ClientTestCase(unittest.TestCase):
         """Test the list_emploistore_services method."""
 
         mock_requests.post(
-            'https://entreprise.pole-emploi.fr/connexion/oauth2/access_token',
+            'https://entreprise.pole-emploi.fr/connexion/oauth2/access_token?realm=%2Fpartenaire',
             json={'access_token': 'foobar'})
         mock_requests.get(
             'https://api.emploi-store.fr/partenaire/cataloguedesservicesemploistore/'
@@ -296,7 +296,7 @@ class ClientTestCase(unittest.TestCase):
         """Test the describe_emploistore_service method."""
 
         mock_requests.post(
-            'https://entreprise.pole-emploi.fr/connexion/oauth2/access_token',
+            'https://entreprise.pole-emploi.fr/connexion/oauth2/access_token?realm=%2Fpartenaire',
             json={'access_token': 'foobar'})
         mock_requests.get(
             'https://api.emploi-store.fr/partenaire/cataloguedesservicesemploistore/'
@@ -318,7 +318,7 @@ class ClientTestCase(unittest.TestCase):
         """Test the list_online_events method."""
 
         mock_requests.post(
-            'https://entreprise.pole-emploi.fr/connexion/oauth2/access_token',
+            'https://entreprise.pole-emploi.fr/connexion/oauth2/access_token?realm=%2Fpartenaire',
             json={'access_token': 'foobar'})
         mock_requests.get(
             'https://api.emploi-store.fr/partenaire/evenements/v1/salonsenligne',
@@ -362,7 +362,7 @@ class PackageTest(unittest.TestCase):
             ])
 
         mock_requests.post(
-            'https://entreprise.pole-emploi.fr/connexion/oauth2/access_token',
+            'https://entreprise.pole-emploi.fr/connexion/oauth2/access_token?realm=%2Fpartenaire',
             json={'access_token': 'foobar'})
         mock_requests.get(
             'https://api.emploi-store.fr/partenaire/infotravail/v1/resource_show?id=bmo-2013-2',
@@ -399,7 +399,7 @@ class ResourceTest(unittest.TestCase):
         """Test the to_csv method."""
 
         mock_requests.post(
-            'https://entreprise.pole-emploi.fr/connexion/oauth2/access_token',
+            'https://entreprise.pole-emploi.fr/connexion/oauth2/access_token?realm=%2Fpartenaire',
             json={'access_token': 'foobar'})
         mock_requests.get(
             'https://api.emploi-store.fr/partenaire/infotravail/v1/datastore_search?'
@@ -429,7 +429,7 @@ class ResourceTest(unittest.TestCase):
         """Test the to_csv method when resource returns numbers directly."""
 
         mock_requests.post(
-            'https://entreprise.pole-emploi.fr/connexion/oauth2/access_token',
+            'https://entreprise.pole-emploi.fr/connexion/oauth2/access_token?realm=%2Fpartenaire',
             json={'access_token': 'foobar'})
         mock_requests.get(
             'https://api.emploi-store.fr/partenaire/infotravail/v1/datastore_search?'
@@ -459,7 +459,7 @@ class ResourceTest(unittest.TestCase):
         """Test the to_csv method when resource has Unicode chars."""
 
         mock_requests.post(
-            'https://entreprise.pole-emploi.fr/connexion/oauth2/access_token',
+            'https://entreprise.pole-emploi.fr/connexion/oauth2/access_token?realm=%2Fpartenaire',
             json={'access_token': 'foobar'})
         mock_requests.get(
             'https://api.emploi-store.fr/partenaire/infotravail/v1/datastore_search?'
@@ -489,7 +489,7 @@ class ResourceTest(unittest.TestCase):
         """Test the to_csv method when resource has the BOM bug."""
 
         mock_requests.post(
-            'https://entreprise.pole-emploi.fr/connexion/oauth2/access_token',
+            'https://entreprise.pole-emploi.fr/connexion/oauth2/access_token?realm=%2Fpartenaire',
             json={'access_token': 'foobar'})
         mock_requests.get(
             'https://api.emploi-store.fr/partenaire/infotravail/v1/datastore_search?'
@@ -519,7 +519,7 @@ class ResourceTest(unittest.TestCase):
         """Test the iterator arg of the to_csv method."""
 
         mock_requests.post(
-            'https://entreprise.pole-emploi.fr/connexion/oauth2/access_token',
+            'https://entreprise.pole-emploi.fr/connexion/oauth2/access_token?realm=%2Fpartenaire',
             json={'access_token': 'foobar'})
         mock_requests.get(
             'https://api.emploi-store.fr/partenaire/infotravail/v1/datastore_search?'
@@ -551,7 +551,7 @@ class ResourceTest(unittest.TestCase):
         """Test the length of the records method."""
 
         mock_requests.post(
-            'https://entreprise.pole-emploi.fr/connexion/oauth2/access_token',
+            'https://entreprise.pole-emploi.fr/connexion/oauth2/access_token?realm=%2Fpartenaire',
             json={'access_token': 'foobar'})
         mock_requests.get(
             'https://api.emploi-store.fr/partenaire/infotravail/v1/datastore_search?'
@@ -573,7 +573,7 @@ class ResourceTest(unittest.TestCase):
         """Test the iterator arg of the to_csv method."""
 
         mock_requests.post(
-            'https://entreprise.pole-emploi.fr/connexion/oauth2/access_token',
+            'https://entreprise.pole-emploi.fr/connexion/oauth2/access_token?realm=%2Fpartenaire',
             json={'access_token': 'foobar'})
         mock_requests.get(
             'https://api.emploi-store.fr/partenaire/infotravail/v1/datastore_search?'


### PR DESCRIPTION
https://www.emploi-store-dev.fr/portail-developpeur-cms/home/catalogue-des-api/documentation-des-api/utiliser-les-api/client-credentials-grant/etape-1---generer-un-access-toke.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bayesimpact/python-emploi-store/40)
<!-- Reviewable:end -->
